### PR TITLE
Kommunestruktur 2018

### DIFF
--- a/boomraader.sas
+++ b/boomraader.sas
@@ -39,6 +39,9 @@ Fylke
 
 ### Endringer
 
+#### Endring Arnfinn 18. juni 2018:
+- Lagt til nye kommunenummer for Trøndelag
+
 #### Endring Arnfinn 7. aug. 2017:
 - Årsbetinget definisjon av opptaksområde (kun 2015 foreløpig, siden Samdata kun har lagt ut til og med 2015) 
 
@@ -98,14 +101,22 @@ else if BoShHN in (9,10,11,12) then BoHF=3; /* Helgeland legges under Nordland h
 else if BoShHN in (9,10,11,12) then BoHF=4;
 %end;
 
-if KomNr in (1632,1633,1702,1703,1711,1714,1717,1718,1719,1721,1724,1725,1736,1738,1739,1740,1742,1743,1744,1748,1749,1750,1751,1755,1756) then BoHF=6;
-else if KomNr in (1567,1612,1613,1617,1620,1621,1622,1624,1627,1630,1634,1635,1636,1638,1640,1644,1648,1653,1657,1662,1663,1664,1665) then BoHF=7;
-else if KomNr in (1601) then do;
+/*
+18. juni 2018:
+Indre Fosen (5054) lagt til St. Olavs, siden flest innbyggere sognet tidligere til St.Olavs. 
+- Rissa (1624) : 6 628 innbyggere
+- Leksvik (1718): 3 480 innbyggere
+Ble sannsynligvis også lagt til St. Olavs i 2018 (Styresak 103/17 Helse Midt-Norge, innkalling til styremøte 21.12.17 https://ekstranett.helse-midt.no/1001/Sakspapirer%20for%20utskrift/Sakspapirer%202017-12-21%20samlehefte%20for%20utskrift.pdf Styremøtet ble avlyst):
+*/
+if KomNr in (1632,5019,1633,5020,1702,5004,1703,5005,1711,5034,1714,5035,1717,5036,1718,1719,5037,1721,5038,1724,5039,1725,5040,1736,5041,1738,5042,1739,5043,1740,5044,1742,5045,1743,5046,1744,5047,1748,5048,1749,5049,1750,5050,1751,5051,1755,5052,1756,5053) then BoHF=6;
+else if KomNr in (1567,1612,5011,1613,5012,1617,5013,1620,5014,1621,5015,1622,5016,1624,1627,5017,1630,5018,1634,5021,1635,5022,1636,5023,1638,5024,1640,5025,1644,5026,1648,5027,1653,5028,1657,5029,1662,5030,1663,5031,1664,5032,1665,5033,5054) then BoHF=7;
+else if KomNr in (1601,5001) then do;
 %if &bydel = 0 %then %do;
    BoHF = 7;
 %end;
 %else %do;
    if Bydel in (160101:160199) then BoHF=7; /*Trondheim - endres ved behov*/
+   if Bydel in (500101:500199) then BoHF=7; /*Trondheim - endres ved behov*/
 %end;
 end;
 else if KomNr in (1502,1504,1505,1511,1514,1515,1516,1517,1519,1520,1523,1524,1525,1526,1528,1529,1531,1532,1534,1535,1539,1543,1545,1546,1547,1548,1551,
@@ -175,7 +186,7 @@ end;
 else if KomNr in (236,402,403,412,415,417,418,419,420,423,425,426,427,428,429,430,432,434,436,437,438,439,441,501,502,511,512,513,514,515,516,517,519,520,521,
 522,528,529,533,534,536,538,540,541,542,543,544,545) then BoHF=19;
 else if KomNr in (219,220,532,602,604,605,612,615,616,617,618,619,620,621,622,623,624,625,626,627,628,631,632,633,711,713) then BoHF=20;
-else if KomNr in (701,702,704,706,709,710,714,716,719,720,722,723,728) then BoHF=21;
+else if KomNr in (701,702,704,706,709,710,712,714,715,716,719,720,722,723,728,729) then BoHF=21;
 else if KomNr in (805,806,807,811,814,815,817,819,821,822,826,827,828,829,830,831,833,834) then BoHF=22;
 else if KomNr in (901,904,906,911,912,914,919,926,928,929,935,937,938,940,941,1001,1002,1003,1004,1014,1017,1018,1021,1026,1027,1029,1032,1034,1037,1046) then BoHF=23;
 else if komNr in (9000,9900,2100,2111,2121,2131,2211,2311,2321) then BoHF=24;

--- a/forny_komnr.sas
+++ b/forny_komnr.sas
@@ -17,162 +17,162 @@ set &datasett;
  1988 
 *******/
 %if &aar ge 1988 %then %do;
-if komnr = 717 then komnr = 701;
-if komnr = 703 then komnr = 701;
-if komnr = 721 then komnr = 704;
-if komnr = 705 then komnr = 704;
-if komnr = 727 then komnr = 709;
-if komnr = 726 then komnr = 709;
-if komnr = 725 then komnr = 709;
-if komnr = 708 then komnr = 709;
-if komnr = 707 then komnr = 709;
+if komnr = 717 then komnr = 701; /* Borre -> Borre */
+if komnr = 703 then komnr = 701; /* Horten -> Borre */
+if komnr = 721 then komnr = 704; /* Sem -> Tønsberg */
+if komnr = 705 then komnr = 704; /* Tønsberg -> Tønsberg */
+if komnr = 727 then komnr = 709; /* Hedrum -> Larvik */
+if komnr = 726 then komnr = 709; /* Brunlanes -> Larvik */
+if komnr = 725 then komnr = 709; /* Tjølling -> Larvik */
+if komnr = 708 then komnr = 709; /* Stavern -> Larvik */
+if komnr = 707 then komnr = 709; /* Larvik -> Larvik */
 %end;
 /*******
  1992 
 *******/
 %if &aar ge 1992 %then %do;
-if komnr = 130 then komnr = 105;
-if komnr = 115 then komnr = 105;
-if komnr = 114 then komnr = 105;
-if komnr = 102 then komnr = 105;
-if komnr = 414 then komnr = 403;
-if komnr = 401 then komnr = 403;
-if komnr = 922 then komnr = 906;
-if komnr = 921 then komnr = 906;
-if komnr = 920 then komnr = 906;
-if komnr = 918 then komnr = 906;
-if komnr = 903 then komnr = 906;
-if komnr = 2016 then komnr = 2004;
-if komnr = 2001 then komnr = 2004;
+if komnr = 130 then komnr = 105; /* Tune -> Sarpsborg */
+if komnr = 115 then komnr = 105; /* Skjeberg -> Sarpsborg */
+if komnr = 114 then komnr = 105; /* Varteig -> Sarpsborg */
+if komnr = 102 then komnr = 105; /* Sarpsborg -> Sarpsborg */
+if komnr = 414 then komnr = 403; /* Vang -> Hamar */
+if komnr = 401 then komnr = 403; /* Hamar -> Hamar */
+if komnr = 922 then komnr = 906; /* Hisøy -> Arendal */
+if komnr = 921 then komnr = 906; /* Tromøy -> Arendal */
+if komnr = 920 then komnr = 906; /* Øyestad -> Arendal */
+if komnr = 918 then komnr = 906; /* Moland -> Arendal */
+if komnr = 903 then komnr = 906; /* Arendal -> Arendal */
+if komnr = 2016 then komnr = 2004; /* Sørøysund -> Hammerfest */
+if komnr = 2001 then komnr = 2004; /* Hammerfest -> Hammerfest */
 %end;
 /*******
  1994 
 *******/
 %if &aar ge 1994 %then %do;
-if komnr = 134 then komnr = 106;
-if komnr = 133 then komnr = 106;
-if komnr = 131 then komnr = 106;
-if komnr = 113 then komnr = 106;
-if komnr = 103 then komnr = 106;
+if komnr = 134 then komnr = 106; /* Onsøy -> Fredrikstad */
+if komnr = 133 then komnr = 106; /* Kråkerøy -> Fredrikstad */
+if komnr = 131 then komnr = 106; /* Rolvsøy -> Fredrikstad */
+if komnr = 113 then komnr = 106; /* Borge -> Fredrikstad */
+if komnr = 103 then komnr = 106; /* Fredrikstad -> Fredrikstad */
 %end;
 /*******
  2002 
 *******/
 %if &aar ge 2002 %then %do;
-if komnr = 718 then komnr = 716;
-if komnr = 716 then komnr = 716;
+if komnr = 718 then komnr = 716; /* Ramnes -> Re */
+/*if komnr = 716 then komnr = 716;*/ /* Våle -> Re */
 %end;
 /*******
  2005 
 *******/
 %if &aar ge 2005 %then %do;
-if komnr = 1842 then komnr = 1804;
-if komnr = 1804 then komnr = 1804;
+if komnr = 1842 then komnr = 1804; /* Skjerstad lagt under Bodø */
+/*if komnr = 1804 then komnr = 1804;*/
 %end;
 /*******
  2006 
 *******/
 %if &aar ge 2006 %then %do;
-if komnr = 1572 then komnr = 1576;
-if komnr = 1569 then komnr = 1576;
-if komnr = 1159 then komnr = 1160;
-if komnr = 1154 then komnr = 1160;
+if komnr = 1572 then komnr = 1576; /* Tustna -> Aure */
+if komnr = 1569 then komnr = 1576; /* Aure -> Aure */
+if komnr = 1159 then komnr = 1160; /* Ølen -> Vindafjord */
+if komnr = 1154 then komnr = 1160; /* Vindafjord -> Vindafjord */
 %end;
 /*******
  2008 
 *******/
 %if &aar ge 2008 %then %do;
-if komnr = 1556 then komnr = 1505;
-if komnr = 1503 then komnr = 1505;
+if komnr = 1556 then komnr = 1505; /* Frei -> Kristiansund */
+if komnr = 1503 then komnr = 1505; /* Kristiansund -> Kristiansund */
 %end;
 /*******
  2012 
 *******/
 %if &aar ge 2012 %then %do;
-if komnr = 1729 then komnr = 1756;
-if komnr = 1723 then komnr = 1756;
+if komnr = 1729 then komnr = 1756; /* Inderøy -> Inderøy */
+if komnr = 1723 then komnr = 1756; /* Mosvik -> Inderøy */
 %end;
 /*******
  2013 
 *******/
 %if &aar ge 2013 %then %do;
-if komnr = 1915 then komnr = 1903;
-if komnr = 1901 then komnr = 1903;
+if komnr = 1915 then komnr = 1903; /* Bjarkøy -> Harstad */
+if komnr = 1901 then komnr = 1903; /* Harstad -> Harstad */
 %end;
 /*******
  2017 
 *******/
 %if &aar ge 2017 %then %do;
-if komnr = 720 then komnr = 710;
-if komnr = 719 then komnr = 710;
-if komnr = 706 then komnr = 710;
+if komnr = 720 then komnr = 710; /* Stokke -> Sandefjord */
+if komnr = 719 then komnr = 710; /* Andebu -> Sandefjord */
+if komnr = 706 then komnr = 710; /* Sandefjord -> Sandefjord */
 %end;
 /*******
  2018 
 *******/
 %if &aar ge 2018 %then %do;
-if komnr = 709 then komnr = 712;
-if komnr = 728 then komnr = 712;
-if komnr = 702 then komnr = 715;
-if komnr = 714 then komnr = 715;
-if komnr = 722 then komnr = 729;
-if komnr = 723 then komnr = 729;
+if komnr = 709 then komnr = 712; /* Larvik -> Larvik */
+if komnr = 728 then komnr = 712; /* Lardal -> Larvik */
+if komnr = 702 then komnr = 715; /* Holmestrand -> Holmestrand */
+if komnr = 714 then komnr = 715; /* Hof -> Holmestrand */
+if komnr = 722 then komnr = 729; /* Nøtterøy -> Færder */
+if komnr = 723 then komnr = 729; /* Tjøme -> Færder */
+if komnr = 1624 then komnr = 5054; /* Rissa -> Indre Fosen */
+if komnr = 1718 then komnr = 5054; /* Leksvik -> Indre Fosen */
 /*
-Trøndelag
+Kun bytte av kommunenummer pga fylkessammenslåing (Trøndelag)
 */
-if komnr = 1601  then komnr = 5001;
+if komnr = 1601 then komnr = 5001;
 if bydel = 160101 then bydel = 500101; /* Midtbyen */
 if bydel = 160102 then bydel = 500102; /* Østbyen */
 if bydel = 160103 then bydel = 500103; /* Lerkendal */
 if bydel = 160104 then bydel = 500104; /* Heimdal */
 if bydel = 160199 then bydel = 500199; /* Uoppgitt bydel Trondheim */
-if komnr = 1702  then komnr = 5004;
-if komnr = 1703  then komnr = 5005;
-if komnr = 1612  then komnr = 5011;
-if komnr = 1613  then komnr = 5012;
-if komnr = 1617  then komnr = 5013;
-if komnr = 1620  then komnr = 5014;
-if komnr = 1621  then komnr = 5015;
-if komnr = 1622  then komnr = 5016;
-if komnr = 1627  then komnr = 5017;
-if komnr = 1630  then komnr = 5018;
-if komnr = 1632  then komnr = 5019;
-if komnr = 1633  then komnr = 5020;
-if komnr = 1634  then komnr = 5021;
-if komnr = 1635  then komnr = 5022;
-if komnr = 1636  then komnr = 5023;
-if komnr = 1638  then komnr = 5024;
-if komnr = 1640  then komnr = 5025;
-if komnr = 1644  then komnr = 5026;
-if komnr = 1648  then komnr = 5027;
-if komnr = 1653  then komnr = 5028;
-if komnr = 1657  then komnr = 5029;
-if komnr = 1662  then komnr = 5030;
-if komnr = 1663  then komnr = 5031;
-if komnr = 1664  then komnr = 5032;
-if komnr = 1665  then komnr = 5033;
-if komnr = 1711  then komnr = 5034;
-if komnr = 1714  then komnr = 5035;
-if komnr = 1717  then komnr = 5036;
-if komnr = 1719  then komnr = 5037;
-if komnr = 1721  then komnr = 5038;
-if komnr = 1724  then komnr = 5039;
-if komnr = 1725  then komnr = 5040;
-if komnr = 1736  then komnr = 5041;
-if komnr = 1738  then komnr = 5042;
-if komnr = 1739  then komnr = 5043;
-if komnr = 1740  then komnr = 5044;
-if komnr = 1742  then komnr = 5045;
-if komnr = 1743  then komnr = 5046;
-if komnr = 1744  then komnr = 5047;
-if komnr = 1748  then komnr = 5048;
-if komnr = 1749  then komnr = 5049;
-if komnr = 1750  then komnr = 5050;
-if komnr = 1751  then komnr = 5051;
-if komnr = 1755  then komnr = 5052;
-if komnr = 1756  then komnr = 5053;
-if komnr = 1624  then komnr = 5054; /* Rissa -> Indre Fosen */
-if komnr = 1718  then komnr = 5054; /* Leksvik -> Indre Fosen */
+if komnr = 1702 then komnr = 5004;
+if komnr = 1703 then komnr = 5005;
+if komnr = 1612 then komnr = 5011;
+if komnr = 1613 then komnr = 5012;
+if komnr = 1617 then komnr = 5013;
+if komnr = 1620 then komnr = 5014;
+if komnr = 1621 then komnr = 5015;
+if komnr = 1622 then komnr = 5016;
+if komnr = 1627 then komnr = 5017;
+if komnr = 1630 then komnr = 5018;
+if komnr = 1632 then komnr = 5019;
+if komnr = 1633 then komnr = 5020;
+if komnr = 1634 then komnr = 5021;
+if komnr = 1635 then komnr = 5022;
+if komnr = 1636 then komnr = 5023;
+if komnr = 1638 then komnr = 5024;
+if komnr = 1640 then komnr = 5025;
+if komnr = 1644 then komnr = 5026;
+if komnr = 1648 then komnr = 5027;
+if komnr = 1653 then komnr = 5028;
+if komnr = 1657 then komnr = 5029;
+if komnr = 1662 then komnr = 5030;
+if komnr = 1663 then komnr = 5031;
+if komnr = 1664 then komnr = 5032;
+if komnr = 1665 then komnr = 5033;
+if komnr = 1711 then komnr = 5034;
+if komnr = 1714 then komnr = 5035;
+if komnr = 1717 then komnr = 5036;
+if komnr = 1719 then komnr = 5037;
+if komnr = 1721 then komnr = 5038;
+if komnr = 1724 then komnr = 5039;
+if komnr = 1725 then komnr = 5040;
+if komnr = 1736 then komnr = 5041;
+if komnr = 1738 then komnr = 5042;
+if komnr = 1739 then komnr = 5043;
+if komnr = 1740 then komnr = 5044;
+if komnr = 1742 then komnr = 5045;
+if komnr = 1743 then komnr = 5046;
+if komnr = 1744 then komnr = 5047;
+if komnr = 1748 then komnr = 5048;
+if komnr = 1749 then komnr = 5049;
+if komnr = 1750 then komnr = 5050;
+if komnr = 1751 then komnr = 5051;
+if komnr = 1755 then komnr = 5052;
+if komnr = 1756 then komnr = 5053;
 %end;
 
 run;

--- a/forny_komnr.sas
+++ b/forny_komnr.sas
@@ -1,0 +1,180 @@
+%macro forny_komnr(datasett = , aar = 2018);
+
+/*!
+Skriv om kommunenummer til siste kommunestruktur
+pr. 1 januar 2018
+
+### Input
+
+- `datasett`: input/output-datasettet
+- `aar`: Hvilket år kommunestrukturen skal hentes fra. Satt til 2018.
+
+*/
+
+data &datasett;
+set &datasett;
+/*******
+ 1988 
+*******/
+%if &aar ge 1988 %then %do;
+if komnr = 717 then komnr = 701;
+if komnr = 703 then komnr = 701;
+if komnr = 721 then komnr = 704;
+if komnr = 705 then komnr = 704;
+if komnr = 727 then komnr = 709;
+if komnr = 726 then komnr = 709;
+if komnr = 725 then komnr = 709;
+if komnr = 708 then komnr = 709;
+if komnr = 707 then komnr = 709;
+%end;
+/*******
+ 1992 
+*******/
+%if &aar ge 1992 %then %do;
+if komnr = 130 then komnr = 105;
+if komnr = 115 then komnr = 105;
+if komnr = 114 then komnr = 105;
+if komnr = 102 then komnr = 105;
+if komnr = 414 then komnr = 403;
+if komnr = 401 then komnr = 403;
+if komnr = 922 then komnr = 906;
+if komnr = 921 then komnr = 906;
+if komnr = 920 then komnr = 906;
+if komnr = 918 then komnr = 906;
+if komnr = 903 then komnr = 906;
+if komnr = 2016 then komnr = 2004;
+if komnr = 2001 then komnr = 2004;
+%end;
+/*******
+ 1994 
+*******/
+%if &aar ge 1994 %then %do;
+if komnr = 134 then komnr = 106;
+if komnr = 133 then komnr = 106;
+if komnr = 131 then komnr = 106;
+if komnr = 113 then komnr = 106;
+if komnr = 103 then komnr = 106;
+%end;
+/*******
+ 2002 
+*******/
+%if &aar ge 2002 %then %do;
+if komnr = 718 then komnr = 716;
+if komnr = 716 then komnr = 716;
+%end;
+/*******
+ 2005 
+*******/
+%if &aar ge 2005 %then %do;
+if komnr = 1842 then komnr = 1804;
+if komnr = 1804 then komnr = 1804;
+%end;
+/*******
+ 2006 
+*******/
+%if &aar ge 2006 %then %do;
+if komnr = 1572 then komnr = 1576;
+if komnr = 1569 then komnr = 1576;
+if komnr = 1159 then komnr = 1160;
+if komnr = 1154 then komnr = 1160;
+%end;
+/*******
+ 2008 
+*******/
+%if &aar ge 2008 %then %do;
+if komnr = 1556 then komnr = 1505;
+if komnr = 1503 then komnr = 1505;
+%end;
+/*******
+ 2012 
+*******/
+%if &aar ge 2012 %then %do;
+if komnr = 1729 then komnr = 1756;
+if komnr = 1723 then komnr = 1756;
+%end;
+/*******
+ 2013 
+*******/
+%if &aar ge 2013 %then %do;
+if komnr = 1915 then komnr = 1903;
+if komnr = 1901 then komnr = 1903;
+%end;
+/*******
+ 2017 
+*******/
+%if &aar ge 2017 %then %do;
+if komnr = 720 then komnr = 710;
+if komnr = 719 then komnr = 710;
+if komnr = 706 then komnr = 710;
+%end;
+/*******
+ 2018 
+*******/
+%if &aar ge 2018 %then %do;
+if komnr = 709 then komnr = 712;
+if komnr = 728 then komnr = 712;
+if komnr = 702 then komnr = 715;
+if komnr = 714 then komnr = 715;
+if komnr = 722 then komnr = 729;
+if komnr = 723 then komnr = 729;
+/*
+Trøndelag
+*/
+if komnr = 1601  then komnr = 5001;
+if bydel = 160101 then bydel = 500101; /* Midtbyen */
+if bydel = 160102 then bydel = 500102; /* Østbyen */
+if bydel = 160103 then bydel = 500103; /* Lerkendal */
+if bydel = 160104 then bydel = 500104; /* Heimdal */
+if bydel = 160199 then bydel = 500199; /* Uoppgitt bydel Trondheim */
+if komnr = 1702  then komnr = 5004;
+if komnr = 1703  then komnr = 5005;
+if komnr = 1612  then komnr = 5011;
+if komnr = 1613  then komnr = 5012;
+if komnr = 1617  then komnr = 5013;
+if komnr = 1620  then komnr = 5014;
+if komnr = 1621  then komnr = 5015;
+if komnr = 1622  then komnr = 5016;
+if komnr = 1627  then komnr = 5017;
+if komnr = 1630  then komnr = 5018;
+if komnr = 1632  then komnr = 5019;
+if komnr = 1633  then komnr = 5020;
+if komnr = 1634  then komnr = 5021;
+if komnr = 1635  then komnr = 5022;
+if komnr = 1636  then komnr = 5023;
+if komnr = 1638  then komnr = 5024;
+if komnr = 1640  then komnr = 5025;
+if komnr = 1644  then komnr = 5026;
+if komnr = 1648  then komnr = 5027;
+if komnr = 1653  then komnr = 5028;
+if komnr = 1657  then komnr = 5029;
+if komnr = 1662  then komnr = 5030;
+if komnr = 1663  then komnr = 5031;
+if komnr = 1664  then komnr = 5032;
+if komnr = 1665  then komnr = 5033;
+if komnr = 1711  then komnr = 5034;
+if komnr = 1714  then komnr = 5035;
+if komnr = 1717  then komnr = 5036;
+if komnr = 1719  then komnr = 5037;
+if komnr = 1721  then komnr = 5038;
+if komnr = 1724  then komnr = 5039;
+if komnr = 1725  then komnr = 5040;
+if komnr = 1736  then komnr = 5041;
+if komnr = 1738  then komnr = 5042;
+if komnr = 1739  then komnr = 5043;
+if komnr = 1740  then komnr = 5044;
+if komnr = 1742  then komnr = 5045;
+if komnr = 1743  then komnr = 5046;
+if komnr = 1744  then komnr = 5047;
+if komnr = 1748  then komnr = 5048;
+if komnr = 1749  then komnr = 5049;
+if komnr = 1750  then komnr = 5050;
+if komnr = 1751  then komnr = 5051;
+if komnr = 1755  then komnr = 5052;
+if komnr = 1756  then komnr = 5053;
+if komnr = 1624  then komnr = 5054; /* Rissa -> Indre Fosen */
+if komnr = 1718  then komnr = 5054; /* Leksvik -> Indre Fosen */
+%end;
+
+run;
+
+%mend;


### PR DESCRIPTION
### Updated boomr-macro with 2018 changes
Included new Larvik (0712), Færder (0729),
new Holmestrand (0715) and Indre Fosen (5054).
New number for kommuner in Trøndelag

### New macro to rewrite all kommunenummer to newest structure

